### PR TITLE
Update unified_log.py

### DIFF
--- a/mac_ripper/src/modules/unifiedlog/unified_log.py
+++ b/mac_ripper/src/modules/unifiedlog/unified_log.py
@@ -98,7 +98,7 @@ class UnifiedLogs:
 <plist version="1.0">
     <dict>
         <key>OSArchiveVersion</key>
-        <integer>4</integer>
+        <integer>2</integer>
     </dict>
 </plist>
         """


### PR DESCRIPTION
OSArchiveVersionのVer.を4にしていたが、4だと時間がずれるという報告がある為2に変更
https://www.mac4n6.com/blog/2020/4/20/analysis-of-apple-unified-log-quarantine-edition-entry-1-converting-log-archive-files-on-1015-catalina